### PR TITLE
Infra, Terraform create public and private subntes inside vpc

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,3 +1,7 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_vpc" "main" {
   cidr_block = var.vpc_cidr
 
@@ -8,6 +12,37 @@ resource "aws_vpc" "main" {
     local.common_tags,
     {
       Name = "${local.name_prefix}-vpc"
+    }
+  )
+}
+
+resource "aws_subnet" "public" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.public_subnet_cidr
+  availability_zone       = data.aws_availability_zones.available.names[0]
+  map_public_ip_on_launch = true
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${local.name_prefix}-public-subnet"
+      Type = "public"
+    }
+  )
+}
+
+resource "aws_subnet" "private" {
+  count = length(var.private_subnet_cidrs)
+
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.private_subnet_cidrs[count.index]
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${local.name_prefix}-private-subnet-${count.index + 1}"
+      Type = "private"
     }
   )
 }

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -7,3 +7,13 @@ output "vpc_cidr" {
   description = "CIDR block of the Tasqly VPC"
   value       = aws_vpc.main.cidr_block
 }
+
+output "public_subnet_id" {
+  description = "ID of the public subnet"
+  value       = aws_subnet.public.id
+}
+
+output "private_subnet_ids" {
+  description = "IDs of the private subnets"
+  value       = aws_subnet.private[*].id
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -9,3 +9,15 @@ variable "vpc_cidr" {
   type        = string
   default     = "10.0.0.0/16"
 }
+
+variable "public_subnet_cidr" {
+  description = "CIDR block for the public subnet"
+  type        = string
+  default     = "10.0.1.0/24"
+}
+
+variable "private_subnet_cidrs" {
+  description = "CIDR blocks for private subnets"
+  type        = list(string)
+  default     = ["10.0.2.0/24", "10.0.3.0/24"]
+}


### PR DESCRIPTION
## Summary

Added the subnet layout for the Tasqly production VPC. This includes one public subnet for the application entry point and private subnets for internal infrastructure such as RDS.

## What Changed

- Added Terraform configuration for the public subnet

- Added Terraform configuration for private subnets

- Attached all subnets to the existing Tasqly VPC

- Assigned non-overlapping CIDR blocks for each subnet

- Applied shared Tasqly tags to subnet resources

- Added Terraform outputs for public and private subnet IDs

## Linked Issue

<!-- Example: Closes #40 -->
Closes #71

## Checklist

- [ ] Code builds locally without errors
- [ ] Linting passes (`npm run lint`)
- [ ] Typecheck passes (`npm run typecheck`)
- [ ] Updated docs / comments where needed