### PR TITLE
Infra, terraform internet gateway and public route table resources

### DIFF
--- a/infra/terraform/locals.tf
+++ b/infra/terraform/locals.tf
@@ -7,3 +7,12 @@ locals {
   }
   name_prefix = "tasqly-prod"
 }
+output "internet_gateway_id" {
+  description = "ID of the Tasqly Internet Gateway"
+  value       = aws_internet_gateway.main.id
+}
+
+output "public_route_table_id" {
+  description = "ID of the public route table"
+  value       = aws_route_table.public.id
+}

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -46,3 +46,35 @@ resource "aws_subnet" "private" {
     }
   )
 }
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${local.name_prefix}-igw"
+    }
+  )
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${local.name_prefix}-public-rt"
+    }
+  )
+}
+
+resource "aws_route" "public_internet_access" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.main.id
+}
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}


### PR DESCRIPTION
## Summary

Configured internet access for the Tasqly public subnet by adding an Internet Gateway, public route table, default internet route, and public subnet route table association.

## What Changed

- Added an Internet Gateway for the Tasqly VPC

- Created a public route table

- Added a `0.0.0.0/0` route through the Internet Gateway

- Associated the public subnet with the public route table

- Applied shared Tasqly tags to networking resources

- Added outputs for the Internet Gateway and public route table

## How to Test

- [ ] `npm run lint` (in `mobile/`)
- [ ] `npm run typecheck` (in `mobile/`)
- [ ] Manual run in Expo (`expo start`)

## Linked Issue

<!-- Example: Closes #40 -->
Closes #72

## Checklist

- [ ] Code builds locally without errors
- [ ] Linting passes (`npm run lint`)
- [ ] Typecheck passes (`npm run typecheck`)
- [ ] Updated docs / comments where needed