### PR TITLE
Infra, Terraform private route table and association resources

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -78,3 +78,21 @@ resource "aws_route_table_association" "public" {
   subnet_id      = aws_subnet.public.id
   route_table_id = aws_route_table.public.id
 }
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.main.id
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${local.name_prefix}-private-rt"
+    }
+  )
+}
+
+resource "aws_route_table_association" "private" {
+  count = length(aws_subnet.private)
+
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private.id
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -17,3 +17,8 @@ output "private_subnet_ids" {
   description = "IDs of the private subnets"
   value       = aws_subnet.private[*].id
 }
+
+output "private_route_table_id" {
+  description = "ID of the private route table"
+  value       = aws_route_table.private.id
+}


### PR DESCRIPTION
## Summary

Configured private subnet routing for Tasqly infrastructure. This keeps internal resources isolated by associating private subnets with a dedicated private route table that does not route directly to the Internet Gateway.

## What Changed

- Added a private route table for the Tasqly VPC

- Associated private subnets with the private route table

- Kept private subnets isolated from direct internet routing

- Applied shared Tasqly tags to private routing resources

- Added Terraform output for the private route table ID

## How to Test

- [ ] `npm run lint` (in `mobile/`)
- [ ] `npm run typecheck` (in `mobile/`)
- [ ] Manual run in Expo (`expo start`)

## Linked Issue

<!-- Example: Closes #40 -->
Closes #73

## Checklist

- [ ] Code builds locally without errors
- [ ] Linting passes (`npm run lint`)
- [ ] Typecheck passes (`npm run typecheck`)
- [ ] Updated docs / comments where needed