### PR TITLE
Infra, Terraform Security groups

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -96,3 +96,61 @@ resource "aws_route_table_association" "private" {
   subnet_id      = aws_subnet.private[count.index].id
   route_table_id = aws_route_table.private.id
 }
+
+resource "aws_security_group" "app" {
+  name        = "${local.name_prefix}-app-sg"
+  description = "Security group for Tasqly application EC2 instance"
+  vpc_id      = aws_vpc.main.id
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${local.name_prefix}-app-sg"
+    }
+  )
+}
+
+resource "aws_vpc_security_group_ingress_rule" "app_https" {
+  security_group_id = aws_security_group.app.id
+
+  cidr_ipv4   = "0.0.0.0/0"
+  from_port   = 443
+  to_port     = 443
+  ip_protocol = "tcp"
+
+  description = "Allow HTTPS from internet"
+}
+
+resource "aws_vpc_security_group_egress_rule" "app_outbound" {
+  security_group_id = aws_security_group.app.id
+
+  cidr_ipv4   = "0.0.0.0/0"
+  ip_protocol = "-1"
+
+  description = "Allow outbound traffic from application"
+}
+
+resource "aws_security_group" "db" {
+  name        = "${local.name_prefix}-db-sg"
+  description = "Security group for Tasqly PostgreSQL database"
+  vpc_id      = aws_vpc.main.id
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${local.name_prefix}-db-sg"
+    }
+  )
+}
+
+resource "aws_vpc_security_group_ingress_rule" "db_postgres_from_app" {
+  security_group_id = aws_security_group.db.id
+
+  referenced_security_group_id = aws_security_group.app.id
+  from_port                    = 5432
+  to_port                      = 5432
+  ip_protocol                  = "tcp"
+
+  description = "Allow PostgreSQL from application security group"
+}
+

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -22,3 +22,13 @@ output "private_route_table_id" {
   description = "ID of the private route table"
   value       = aws_route_table.private.id
 }
+
+output "app_security_group_id" {
+  description = "ID of the application security group"
+  value       = aws_security_group.app.id
+}
+
+output "db_security_group_id" {
+  description = "ID of the database security group"
+  value       = aws_security_group.db.id
+}


### PR DESCRIPTION
## Summary

Added security groups for the Tasqly application and database layers. This defines least-privilege network access between EC2 and RDS.

## What Changed

- Added application security group for the EC2 backend

- Added database security group for RDS PostgreSQL

- Allowed inbound HTTPS traffic to the application security group

- Allowed outbound traffic from the application security group

- Restricted PostgreSQL access to only the application security group

- Prevented public database access on port `5432`

- Applied shared Tasqly tags to security group resources

- Added Terraform outputs for security group IDs

## How to Test

- [ ] `npm run lint` (in `mobile/`)
- [ ] `npm run typecheck` (in `mobile/`)
- [ ] Manual run in Expo (`expo start`)

## Linked Issue

<!-- Example: Closes #40 -->
Closes #74

## Checklist

- [ ] Code builds locally without errors
- [ ] Linting passes (`npm run lint`)
- [ ] Typecheck passes (`npm run typecheck`)
- [ ] Updated docs / comments where needed