### PR TITLE
add IAM role and instance profile for EC2 application with correspond…

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -154,3 +154,39 @@ resource "aws_vpc_security_group_ingress_rule" "db_postgres_from_app" {
   description = "Allow PostgreSQL from application security group"
 }
 
+resource "aws_iam_role" "ec2_app" {
+  name = "${local.name_prefix}-ec2-app-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${local.name_prefix}-ec2-app-role"
+    }
+  )
+}
+
+resource "aws_iam_instance_profile" "ec2_app" {
+  name = "${local.name_prefix}-ec2-app-profile"
+  role = aws_iam_role.ec2_app.name
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${local.name_prefix}-ec2-app-profile"
+    }
+  )
+}
+

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -32,3 +32,13 @@ output "db_security_group_id" {
   description = "ID of the database security group"
   value       = aws_security_group.db.id
 }
+
+output "ec2_app_role_name" {
+  description = "Name of the EC2 application IAM role"
+  value       = aws_iam_role.ec2_app.name
+}
+
+output "ec2_app_instance_profile_name" {
+  description = "Name of the EC2 application instance profile"
+  value       = aws_iam_instance_profile.ec2_app.name
+}


### PR DESCRIPTION
## Summary

Added the IAM role and instance profile required for the Tasqly EC2 application runtime. This prepares the EC2 instance to receive scoped AWS permissions through future least-privilege policies.

## What Changed

- Added EC2 application IAM role

- Configured the role trust policy so it can only be assumed by EC2

- Added EC2 instance profile linked to the application IAM role

- Applied shared Tasqly tags where supported

- Added Terraform outputs for the role and instance profile

- Kept the role minimal with no broad runtime permissions attached

## How to Test

- [ ] `npm run lint` (in `mobile/`)
- [ ] `npm run typecheck` (in `mobile/`)
- [ ] Manual run in Expo (`expo start`)

## Linked Issue

<!-- Example: Closes #40 -->
Closes #76

## Checklist

- [ ] Code builds locally without errors
- [ ] Linting passes (`npm run lint`)
- [ ] Typecheck passes (`npm run typecheck`)
- [ ] Updated docs / comments where needed