### PR TITLE
Infra, Terraform EC2 instance resource and custom AMI

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -190,3 +190,21 @@ resource "aws_iam_instance_profile" "ec2_app" {
   )
 }
 
+
+
+resource "aws_instance" "app" {
+  ami           = var.app_ami_id
+  instance_type = var.app_instance_type
+
+  subnet_id                   = aws_subnet.public.id
+  vpc_security_group_ids      = [aws_security_group.app.id]
+  iam_instance_profile        = aws_iam_instance_profile.ec2_app.name
+  associate_public_ip_address = true
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${local.name_prefix}-app-ec2"
+    }
+  )
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -42,3 +42,12 @@ output "ec2_app_instance_profile_name" {
   description = "Name of the EC2 application instance profile"
   value       = aws_iam_instance_profile.ec2_app.name
 }
+output "app_instance_id" {
+  description = "ID of the Tasqly application EC2 instance"
+  value       = aws_instance.app.id
+}
+
+output "app_public_ip" {
+  description = "Public IP of the Tasqly application EC2 instance"
+  value       = aws_instance.app.public_ip
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -21,3 +21,15 @@ variable "private_subnet_cidrs" {
   type        = list(string)
   default     = ["10.0.2.0/24", "10.0.3.0/24"]
 }
+
+variable "app_ami_id" {
+  description = "Custom AMI ID for the Tasqly application EC2 instance"
+  type        = string
+}
+
+variable "app_instance_type" {
+  description = "EC2 instance type for the Tasqly application host"
+  type        = string
+  default     = "t3.micro"
+}
+


### PR DESCRIPTION
## Summary

Provisioned the Tasqly EC2 application host using a custom AMI prepared with the required backend runtime tooling. The instance is deployed in the public subnet and configured as the main application runtime entry point.

## What Changed

- Created a custom AMI for the Tasqly backend host

- Prepared the AMI with Docker, Git, curl, and K3s

- Added Terraform variable support for the custom AMI ID

- Provisioned the EC2 application instance using the custom AMI

- Launched the EC2 instance in the public subnet

- Attached the application security group

- Attached the EC2 instance profile

- Added Terraform outputs for the EC2 instance ID and public IP

- Applied shared Tasqly tags to the EC2 instance

## How to Test

- [ ] `npm run lint` (in `mobile/`)
- [ ] `npm run typecheck` (in `mobile/`)
- [ ] Manual run in Expo (`expo start`)

## Linked Issue

<!-- Example: Closes #40 -->
Closes #75

## Checklist

- [ ] Code builds locally without errors
- [ ] Linting passes (`npm run lint`)
- [ ] Typecheck passes (`npm run typecheck`)
- [ ] Updated docs / comments where needed