### PR TITLE
Infra, Terraform RDS PostgreSQL database

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -208,3 +208,46 @@ resource "aws_instance" "app" {
     }
   )
 }
+
+resource "aws_db_subnet_group" "main" {
+  name       = "${local.name_prefix}-db-subnet-group"
+  subnet_ids = aws_subnet.private[*].id
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${local.name_prefix}-db-subnet-group"
+    }
+  )
+}
+
+resource "aws_db_instance" "postgres" {
+  identifier = "${local.name_prefix}-postgres"
+
+  engine         = "postgres"
+  engine_version = "16"
+  instance_class = var.db_instance_class
+
+  allocated_storage = 20
+  storage_type      = "gp3"
+
+  db_name  = var.db_name
+  username = var.db_username
+  password = var.db_password
+
+  db_subnet_group_name   = aws_db_subnet_group.main.name
+  vpc_security_group_ids = [aws_security_group.db.id]
+
+  publicly_accessible = false
+  skip_final_snapshot = true
+
+  backup_retention_period = 7
+  deletion_protection     = false
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${local.name_prefix}-postgres"
+    }
+  )
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -51,3 +51,13 @@ output "app_public_ip" {
   description = "Public IP of the Tasqly application EC2 instance"
   value       = aws_instance.app.public_ip
 }
+
+output "db_instance_endpoint" {
+  description = "RDS PostgreSQL endpoint"
+  value       = aws_db_instance.postgres.endpoint
+}
+
+output "db_instance_name" {
+  description = "RDS PostgreSQL database name"
+  value       = aws_db_instance.postgres.db_name
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -33,3 +33,26 @@ variable "app_instance_type" {
   default     = "t3.micro"
 }
 
+variable "db_name" {
+  description = "Name of the Tasqly PostgreSQL database"
+  type        = string
+  default     = "tasqly"
+}
+
+variable "db_username" {
+  description = "Master username for the Tasqly database"
+  type        = string
+  default     = "tasqly_admin"
+}
+
+variable "db_password" {
+  description = "Master password for the Tasqly database"
+  type        = string
+  sensitive   = true
+}
+
+variable "db_instance_class" {
+  description = "RDS instance class"
+  type        = string
+  default     = "db.t3.micro"
+}


### PR DESCRIPTION
## Summary

Provisioned the Tasqly PostgreSQL database using Amazon RDS. The database is deployed in private subnets, attached to the database security group, and configured to remain inaccessible from the public internet.

## What Changed

- Added RDS PostgreSQL instance configuration

- Added DB subnet group using private subnets

- Attached the database security group to RDS

- Configured RDS as not publicly accessible

- Added cost-aware database sizing

- Added database variables for name, username, password, and instance class

- Marked database password as sensitive

- Added Terraform outputs for database endpoint and database name

- Applied shared Tasqly tags to RDS resources

## How to Test

- [ ] `npm run lint` (in `mobile/`)
- [ ] `npm run typecheck` (in `mobile/`)
- [ ] Manual run in Expo (`expo start`)

## Linked Issue

<!-- Example: Closes #40 -->
Closes #77

## Checklist

- [ ] Code builds locally without errors
- [ ] Linting passes (`npm run lint`)
- [ ] Typecheck passes (`npm run typecheck`)
- [ ] Updated docs / comments where needed