### PR TITLE
Infra, Terraform S3 bucket for uploads

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -251,3 +251,33 @@ resource "aws_db_instance" "postgres" {
     }
   )
 }
+
+resource "aws_s3_bucket" "uploads" {
+  bucket = var.uploads_bucket_name
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${local.name_prefix}-uploads"
+    }
+  )
+}
+
+resource "aws_s3_bucket_public_access_block" "uploads" {
+  bucket = aws_s3_bucket.uploads.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "uploads" {
+  bucket = aws_s3_bucket.uploads.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -61,3 +61,13 @@ output "db_instance_name" {
   description = "RDS PostgreSQL database name"
   value       = aws_db_instance.postgres.db_name
 }
+
+output "uploads_bucket_name" {
+  description = "Name of the Tasqly uploads S3 bucket"
+  value       = aws_s3_bucket.uploads.bucket
+}
+
+output "uploads_bucket_arn" {
+  description = "ARN of the Tasqly uploads S3 bucket"
+  value       = aws_s3_bucket.uploads.arn
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -56,3 +56,10 @@ variable "db_instance_class" {
   type        = string
   default     = "db.t3.micro"
 }
+
+variable "uploads_bucket_name" {
+  description = "S3 bucket name for Tasqly application uploads"
+  type        = string
+  default     = "tasqly-prod-uploads"
+}
+


### PR DESCRIPTION
## Summary

Created a private S3 bucket for Tasqly application uploads. This bucket will store media files such as repair request photos, receipts, and other task-related uploads.

## What Changed

- Added Terraform configuration for the Tasqly uploads S3 bucket

- Configured the bucket to block all public access

- Enabled server-side encryption for uploaded objects

- Added shared Tasqly tags to the bucket

- Added Terraform outputs for the uploads bucket name and ARN

## How to Test

- [ ] `npm run lint` (in `mobile/`)
- [ ] `npm run typecheck` (in `mobile/`)
- [ ] Manual run in Expo (`expo start`)

## Linked Issue

<!-- Example: Closes #40 -->
Closes #78

## Checklist

- [ ] Code builds locally without errors
- [ ] Linting passes (`npm run lint`)
- [ ] Typecheck passes (`npm run typecheck`)
- [ ] Updated docs / comments where needed