### PR TITLE
Infra, Terraform IAM policy and role attachment for EC2 access to S3 uploads bucket

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -281,3 +281,44 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "uploads" {
     }
   }
 }
+
+resource "aws_iam_policy" "ec2_uploads_s3_access" {
+  name        = "${local.name_prefix}-ec2-uploads-s3-access"
+  description = "Allow EC2 application role to access Tasqly uploads bucket"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ListUploadsBucket"
+        Effect = "Allow"
+        Action = [
+          "s3:ListBucket"
+        ]
+        Resource = aws_s3_bucket.uploads.arn
+      },
+      {
+        Sid    = "ReadWriteUploadsObjects"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject"
+        ]
+        Resource = "${aws_s3_bucket.uploads.arn}/*"
+      }
+    ]
+  })
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${local.name_prefix}-ec2-uploads-s3-access"
+    }
+  )
+}
+
+resource "aws_iam_role_policy_attachment" "ec2_uploads_s3_access" {
+  role       = aws_iam_role.ec2_app.name
+  policy_arn = aws_iam_policy.ec2_uploads_s3_access.arn
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -71,3 +71,8 @@ output "uploads_bucket_arn" {
   description = "ARN of the Tasqly uploads S3 bucket"
   value       = aws_s3_bucket.uploads.arn
 }
+
+output "ec2_uploads_s3_policy_arn" {
+  description = "ARN of the EC2 uploads S3 access policy"
+  value       = aws_iam_policy.ec2_uploads_s3_access.arn
+}


### PR DESCRIPTION
## Summary

Granted the Tasqly EC2 application role limited access to the private S3 uploads bucket. This allows the backend application to read, write, list, and delete uploaded media files without exposing the bucket publicly.

## What Changed

- Added a scoped IAM policy for S3 uploads bucket access

- Allowed the EC2 application role to list only the Tasqly uploads bucket

- Allowed object-level read, write, and delete access only within the uploads bucket

- Attached the scoped policy to the EC2 application role

- Avoided broad S3 access across the AWS account

- Added Terraform output for the S3 access policy ARN

## How to Test

- [ ] `npm run lint` (in `mobile/`)
- [ ] `npm run typecheck` (in `mobile/`)
- [ ] Manual run in Expo (`expo start`)

## Linked Issue

<!-- Example: Closes #40 -->
Closes #79

## Checklist

- [ ] Code builds locally without errors
- [ ] Linting passes (`npm run lint`)
- [ ] Typecheck passes (`npm run typecheck`)
- [ ] Updated docs / comments where needed