### PR TITLE
Infra, Terraform ECR repository and lifecycle policy for backend images

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -322,3 +322,40 @@ resource "aws_iam_role_policy_attachment" "ec2_uploads_s3_access" {
   role       = aws_iam_role.ec2_app.name
   policy_arn = aws_iam_policy.ec2_uploads_s3_access.arn
 }
+
+resource "aws_ecr_repository" "backend" {
+  name                 = var.backend_ecr_repository_name
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${local.name_prefix}-backend-ecr"
+    }
+  )
+}
+
+resource "aws_ecr_lifecycle_policy" "backend" {
+  repository = aws_ecr_repository.backend.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Keep last 10 images"
+        selection = {
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = 10
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -76,3 +76,13 @@ output "ec2_uploads_s3_policy_arn" {
   description = "ARN of the EC2 uploads S3 access policy"
   value       = aws_iam_policy.ec2_uploads_s3_access.arn
 }
+
+output "backend_ecr_repository_url" {
+  description = "URL of the Tasqly backend ECR repository"
+  value       = aws_ecr_repository.backend.repository_url
+}
+
+output "backend_ecr_repository_arn" {
+  description = "ARN of the Tasqly backend ECR repository"
+  value       = aws_ecr_repository.backend.arn
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -63,3 +63,8 @@ variable "uploads_bucket_name" {
   default     = "tasqly-prod-uploads"
 }
 
+variable "backend_ecr_repository_name" {
+  description = "ECR repository name for Tasqly backend images"
+  type        = string
+  default     = "tasqly-prod-backend"
+}


### PR DESCRIPTION
## Summary

Created a private Amazon ECR repository for storing Tasqly backend container images. The repository is configured with image scanning and a lifecycle policy to manage stored images efficiently.

## What Changed

- Added Terraform configuration for the private ECR repository

- Configured repository with mutable image tags for development flexibility

- Enabled image scanning on push

- Added lifecycle policy to retain only the most recent images

- Applied shared Tasqly tags to the repository

- Added Terraform outputs for repository URL and ARN

## How to Test

- [ ] `npm run lint` (in `mobile/`)
- [ ] `npm run typecheck` (in `mobile/`)
- [ ] Manual run in Expo (`expo start`)

## Linked Issue

<!-- Example: Closes #40 -->
Closes #80

## Checklist

- [ ] Code builds locally without errors
- [ ] Linting passes (`npm run lint`)
- [ ] Typecheck passes (`npm run typecheck`)
- [ ] Updated docs / comments where needed