### PR TITLE
Infra, Terraform IAM policy and role attachment for EC2 access to ECR

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -359,3 +359,44 @@ resource "aws_ecr_lifecycle_policy" "backend" {
     ]
   })
 }
+
+resource "aws_iam_policy" "ec2_ecr_pull_access" {
+  name        = "${local.name_prefix}-ec2-ecr-pull-access"
+  description = "Allow EC2 application role to pull backend images from Tasqly ECR"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "GetECRAuthorizationToken"
+        Effect = "Allow"
+        Action = [
+          "ecr:GetAuthorizationToken"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "PullBackendImages"
+        Effect = "Allow"
+        Action = [
+          "ecr:BatchGetImage",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchCheckLayerAvailability"
+        ]
+        Resource = aws_ecr_repository.backend.arn
+      }
+    ]
+  })
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${local.name_prefix}-ec2-ecr-pull-access"
+    }
+  )
+}
+
+resource "aws_iam_role_policy_attachment" "ec2_ecr_pull_access" {
+  role       = aws_iam_role.ec2_app.name
+  policy_arn = aws_iam_policy.ec2_ecr_pull_access.arn
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -86,3 +86,8 @@ output "backend_ecr_repository_arn" {
   description = "ARN of the Tasqly backend ECR repository"
   value       = aws_ecr_repository.backend.arn
 }
+
+output "ec2_ecr_pull_policy_arn" {
+  description = "ARN of the EC2 ECR pull access policy"
+  value       = aws_iam_policy.ec2_ecr_pull_access.arn
+}


### PR DESCRIPTION
## Summary

Granted the Tasqly EC2 application role limited pull access to the private backend ECR repository. This allows the EC2 runtime to authenticate with ECR and pull backend container images without receiving push or admin permissions.

## What Changed

- Added scoped IAM policy for ECR pull access

- Allowed EC2 role to authenticate with ECR

- Allowed EC2 role to pull images from the Tasqly backend ECR repository

- Scoped image pull permissions to the backend ECR repository

- Attached the policy to the EC2 application role

- Avoided ECR push and admin permissions

- Added Terraform output for the ECR pull policy ARN

## How to Test

- [ ] `npm run lint` (in `mobile/`)
- [ ] `npm run typecheck` (in `mobile/`)
- [ ] Manual run in Expo (`expo start`)

## Linked Issue

<!-- Example: Closes #40 -->
Closes #81

## Checklist

- [ ] Code builds locally without errors
- [ ] Linting passes (`npm run lint`)
- [ ] Typecheck passes (`npm run typecheck`)
- [ ] Updated docs / comments where needed