### PR TITLE
Infra, Terraform AWS Secrets Manager resource

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -400,3 +400,15 @@ resource "aws_iam_role_policy_attachment" "ec2_ecr_pull_access" {
   role       = aws_iam_role.ec2_app.name
   policy_arn = aws_iam_policy.ec2_ecr_pull_access.arn
 }
+
+resource "aws_secretsmanager_secret" "app_secrets" {
+  name        = "${local.name_prefix}/application/secrets"
+  description = "Application secrets for Tasqly backend"
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${local.name_prefix}-application-secrets"
+    }
+  )
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -91,3 +91,13 @@ output "ec2_ecr_pull_policy_arn" {
   description = "ARN of the EC2 ECR pull access policy"
   value       = aws_iam_policy.ec2_ecr_pull_access.arn
 }
+
+output "app_secrets_name" {
+  description = "Name of the Tasqly application secrets entry"
+  value       = aws_secretsmanager_secret.app_secrets.name
+}
+
+output "app_secrets_arn" {
+  description = "ARN of the Tasqly application secrets entry"
+  value       = aws_secretsmanager_secret.app_secrets.arn
+}


### PR DESCRIPTION
## Summary

Provisioned an AWS Secrets Manager secret container for Tasqly application secrets. This prepares a secure location for manually storing database credentials and future application configuration secrets.

## What Changed

- Added Terraform configuration for a single Tasqly application secret in AWS Secrets Manager

- Created the secret resource/container only, without storing plaintext values in Terraform

- Used Tasqly naming convention: `tasqly-prod/application/secrets`

- Applied shared Tasqly tags to the secret

- Added Terraform outputs for the secret name and ARN

- Confirmed database credentials will be added manually outside Terraform

## How to Test

- [ ] `npm run lint` (in `mobile/`)
- [ ] `npm run typecheck` (in `mobile/`)
- [ ] Manual run in Expo (`expo start`)

## Linked Issue

<!-- Example: Closes #40 -->
Closes #82

## Checklist

- [ ] Code builds locally without errors
- [ ] Linting passes (`npm run lint`)
- [ ] Typecheck passes (`npm run typecheck`)
- [ ] Updated docs / comments where needed