### PR TITLE
Infra, Terraform IAM policy for EC2 to read application secrets

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -412,3 +412,36 @@ resource "aws_secretsmanager_secret" "app_secrets" {
     }
   )
 }
+
+resource "aws_iam_policy" "ec2_secrets_read_access" {
+  name        = "${local.name_prefix}-ec2-secrets-read-access"
+  description = "Allow EC2 application role to read Tasqly application secrets"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ReadTasqlyApplicationSecrets"
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:DescribeSecret"
+        ]
+        Resource = aws_secretsmanager_secret.app_secrets.arn
+      }
+    ]
+  })
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${local.name_prefix}-ec2-secrets-read-access"
+    }
+  )
+}
+
+resource "aws_iam_role_policy_attachment" "ec2_secrets_read_access" {
+  role       = aws_iam_role.ec2_app.name
+  policy_arn = aws_iam_policy.ec2_secrets_read_access.arn
+}
+

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -101,3 +101,8 @@ output "app_secrets_arn" {
   description = "ARN of the Tasqly application secrets entry"
   value       = aws_secretsmanager_secret.app_secrets.arn
 }
+
+output "ec2_secrets_read_policy_arn" {
+  description = "ARN of the EC2 Secrets Manager read access policy"
+  value       = aws_iam_policy.ec2_secrets_read_access.arn
+}


### PR DESCRIPTION
## Summary

Granted the Tasqly EC2 application role limited read access to the application secrets stored in AWS Secrets Manager. This allows the backend runtime to retrieve required configuration values without giving it permission to manage or modify secrets.

## What Changed

- Added scoped IAM policy for Secrets Manager read access

- Allowed EC2 role to read the Tasqly application secret only

- Allowed `GetSecretValue` and `DescribeSecret` actions

- Attached the policy to the EC2 application role

- Avoided broad access to all Secrets Manager secrets

- Prevented EC2 role from creating, updating, or deleting secrets

- Added Terraform output for the Secrets Manager read policy ARN
## How to Test

- [ ] `npm run lint` (in `mobile/`)
- [ ] `npm run typecheck` (in `mobile/`)
- [ ] Manual run in Expo (`expo start`)

## Linked Issue

<!-- Example: Closes #40 -->
Closes #83

## Checklist

- [ ] Code builds locally without errors
- [ ] Linting passes (`npm run lint`)
- [ ] Typecheck passes (`npm run typecheck`)
- [ ] Updated docs / comments where needed