### PR TITLE
Infra, Terraform CloudWatch log groups

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -445,3 +445,26 @@ resource "aws_iam_role_policy_attachment" "ec2_secrets_read_access" {
   policy_arn = aws_iam_policy.ec2_secrets_read_access.arn
 }
 
+resource "aws_cloudwatch_log_group" "app" {
+  name              = "/tasqly/prod/application"
+  retention_in_days = var.cloudwatch_log_retention_days
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${local.name_prefix}-application-logs"
+    }
+  )
+}
+
+resource "aws_cloudwatch_log_group" "k3s" {
+  name              = "/tasqly/prod/k3s"
+  retention_in_days = var.cloudwatch_log_retention_days
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${local.name_prefix}-k3s-logs"
+    }
+  )
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -106,3 +106,13 @@ output "ec2_secrets_read_policy_arn" {
   description = "ARN of the EC2 Secrets Manager read access policy"
   value       = aws_iam_policy.ec2_secrets_read_access.arn
 }
+
+output "app_log_group_name" {
+  description = "Name of the Tasqly application CloudWatch log group"
+  value       = aws_cloudwatch_log_group.app.name
+}
+
+output "k3s_log_group_name" {
+  description = "Name of the Tasqly K3s CloudWatch log group"
+  value       = aws_cloudwatch_log_group.k3s.name
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -68,3 +68,9 @@ variable "backend_ecr_repository_name" {
   type        = string
   default     = "tasqly-prod-backend"
 }
+
+variable "cloudwatch_log_retention_days" {
+  description = "Number of days to retain CloudWatch logs"
+  type        = number
+  default     = 14
+}


### PR DESCRIPTION
## Summary

Configured CloudWatch log groups for Tasqly application and runtime visibility. This prepares the infrastructure for future EC2 and Kubernetes log shipping while keeping log retention cost-aware.

## What Changed

- Added CloudWatch log group for Tasqly application logs

- Added CloudWatch log group for K3s/runtime logs

- Configured log retention to avoid unnecessary cost growth

- Added shared Tasqly tags where supported

- Added Terraform outputs for log group names

## How to Test

- [ ] `npm run lint` (in `mobile/`)
- [ ] `npm run typecheck` (in `mobile/`)
- [ ] Manual run in Expo (`expo start`)

## Linked Issue

<!-- Example: Closes #40 -->
Closes #84

## Checklist

- [ ] Code builds locally without errors
- [ ] Linting passes (`npm run lint`)
- [ ] Typecheck passes (`npm run typecheck`)
- [ ] Updated docs / comments where needed