### PR TITLE
Infra, Terraform IAM policy and output for EC2 CloudWatch logs access

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -468,3 +468,39 @@ resource "aws_cloudwatch_log_group" "k3s" {
     }
   )
 }
+
+resource "aws_iam_policy" "ec2_cloudwatch_logs_access" {
+  name        = "${local.name_prefix}-ec2-cloudwatch-logs-access"
+  description = "Allow EC2 application role to write logs to Tasqly CloudWatch log groups"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "WriteTasqlyLogs"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:DescribeLogStreams"
+        ]
+        Resource = [
+          "${aws_cloudwatch_log_group.app.arn}:*",
+          "${aws_cloudwatch_log_group.k3s.arn}:*"
+        ]
+      }
+    ]
+  })
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${local.name_prefix}-ec2-cloudwatch-logs-access"
+    }
+  )
+}
+
+resource "aws_iam_role_policy_attachment" "ec2_cloudwatch_logs_access" {
+  role       = aws_iam_role.ec2_app.name
+  policy_arn = aws_iam_policy.ec2_cloudwatch_logs_access.arn
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -116,3 +116,8 @@ output "k3s_log_group_name" {
   description = "Name of the Tasqly K3s CloudWatch log group"
   value       = aws_cloudwatch_log_group.k3s.name
 }
+
+output "ec2_cloudwatch_logs_policy_arn" {
+  description = "ARN of the EC2 CloudWatch logs access policy"
+  value       = aws_iam_policy.ec2_cloudwatch_logs_access.arn
+}


### PR DESCRIPTION
## Summary

Granted the Tasqly EC2 application role limited permissions to write logs to the configured CloudWatch log groups. This prepares the EC2 runtime to send application and K3s logs without giving it CloudWatch admin access.

## What Changed

- Added scoped IAM policy for CloudWatch log writing

- Allowed EC2 role to create log streams

- Allowed EC2 role to write log events

- Allowed EC2 role to describe log streams

- Scoped access to Tasqly CloudWatch log groups only

- Attached the policy to the EC2 application role

- Added Terraform output for the CloudWatch logs policy ARN

## How to Test

- [ ] `npm run lint` (in `mobile/`)
- [ ] `npm run typecheck` (in `mobile/`)
- [ ] Manual run in Expo (`expo start`)

## Linked Issue

<!-- Example: Closes #40 -->
Closes #85

## Checklist

- [ ] Code builds locally without errors
- [ ] Linting passes (`npm run lint`)
- [ ] Typecheck passes (`npm run typecheck`)
- [ ] Updated docs / comments where needed