### PR TITLE
K8s Readiness and liveness probes for deployments

### DIFF
--- a/infra/k8s/prod/deployment.yaml
+++ b/infra/k8s/prod/deployment.yaml
@@ -22,7 +22,25 @@ spec:
     spec:
       containers:
         - name: tasqly-backend
-          image: 222907083284.dkr.ecr.ca-central-1.amazonaws.com/tasqly-prod-backend:hello
+          image: 222907083284.dkr.ecr.ca-central-1.amazonaws.com/tasqly-prod-backend:hello-amd64
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
+
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 3


### PR DESCRIPTION
## Summary

Added Kubernetes readiness and liveness probes to the Tasqly backend Deployment.

## Changes

- Added a readiness probe for the backend container
- Added a liveness probe for the backend container
- Configured both probes to use the Spring Boot Actuator health endpoint
- Set startup-friendly probe timing for the Spring Boot application
- Ensured Kubernetes can detect when the backend is ready or unhealthy

## Health Endpoint

```text
/actuator/health
```

## How to Test

- [ ] `npm run lint` (in `mobile/`)
- [ ] `npm run typecheck` (in `mobile/`)
- [ ] Manual run in Expo (`expo start`)

## Linked Issue

<!-- Example: Closes #40 -->
Closes #110 

## Checklist

- [ ] Code builds locally without errors
- [ ] Linting passes (`npm run lint`)
- [ ] Typecheck passes (`npm run typecheck`)
- [ ] Updated docs / comments where needed