### PR TITLE
infra, K8s ConfigMap

### DIFF
--- a/infra/k8s/prod/configmap.yaml
+++ b/infra/k8s/prod/configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tasqly-backend-config
+  namespace: tasqly-prod
+  labels:
+    app.kubernetes.io/name: tasqly
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/environment: prod
+data:
+  SPRING_PROFILES_ACTIVE: "prod"
+  SERVER_PORT: "8080"
+  SPRING_JPA_OPEN_IN_VIEW: "false"

--- a/infra/k8s/prod/deployment.yaml
+++ b/infra/k8s/prod/deployment.yaml
@@ -20,10 +20,20 @@ spec:
         app.kubernetes.io/component: backend
         app.kubernetes.io/environment: prod
     spec:
+      imagePullSecrets:
+        - name: ecr-pull-secret
+
       containers:
         - name: tasqly-backend
           image: 222907083284.dkr.ecr.ca-central-1.amazonaws.com/tasqly-prod-backend:hello-amd64
           imagePullPolicy: Always
+
+          envFrom:
+            - configMapRef:
+                name: tasqly-backend-config
+            - secretRef:
+                name: tasqly-backend-db-secret
+
           ports:
             - containerPort: 8080
 


### PR DESCRIPTION
## Summary

Added Kubernetes ConfigMap support for the Tasqly backend application and updated the Deployment to consume runtime configuration from Kubernetes resources.

## Changes

- Created the backend ConfigMap manifest

- Added non-secret production configuration values

- Updated the backend Deployment to consume values from the ConfigMap

- Kept database credentials in the existing Kubernetes Secret

- Preserved ECR image pull secret configuration

- Preserved readiness and liveness probes

## ConfigMap Values

```text

SPRING_PROFILES_ACTIVE=prod

SERVER_PORT=8080

SPRING_JPA_OPEN_IN_VIEW=false
```

## How to Test

- [ ] `npm run lint` (in `mobile/`)
- [ ] `npm run typecheck` (in `mobile/`)
- [ ] Manual run in Expo (`expo start`)

## Linked Issue

<!-- Example: Closes #40 -->
Closes #111

## Checklist

- [ ] Code builds locally without errors
- [ ] Linting passes (`npm run lint`)
- [ ] Typecheck passes (`npm run typecheck`)
- [ ] Updated docs / comments where needed