### PR TITLE
Infra, K8s Ingress resource configuration

### DIFF
--- a/infra/k8s/prod/ingress.yaml
+++ b/infra/k8s/prod/ingress.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tasqly-backend
+  namespace: tasqly-prod
+  labels:
+    app.kubernetes.io/name: tasqly
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/environment: prod
+spec:
+  ingressClassName: traefik
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: tasqly-backend
+                port:
+                  number: 8080


### PR DESCRIPTION
## Summary

Added Kubernetes Ingress support for external access to the Tasqly backend through the K3s Traefik Ingress controller.

## Changes

- Created the backend Ingress manifest
- Configured the Ingress to run in the `tasqly-prod` namespace
- Used the `traefik` ingress class
- Routed external HTTP traffic to the `tasqly-backend` Service
- Preserved the backend Service as `ClusterIP`
- Prepared the backend for access through the EC2 public entry point

## Validation

- Confirmed Traefik is running in the K3s cluster
- Confirmed the Traefik Service exposes ports `80` and `443`
- Ingress manifest exists under `infra/k8s/prod/`
- Ingress routes traffic to the backend Service on port `8080`
- Backend can be tested externally through the EC2 public IP after port `80` is allowed in the EC2 security group

## Test Commands

```bash
curl http://16.54.243.37/api/hello
curl http://16.54.243.37/actuator/health
```

## How to Test

- [ ] `npm run lint` (in `mobile/`)
- [ ] `npm run typecheck` (in `mobile/`)
- [ ] Manual run in Expo (`expo start`)

## Linked Issue

<!-- Example: Closes #40 -->
Closes #114

## Checklist

- [ ] Code builds locally without errors
- [ ] Linting passes (`npm run lint`)
- [ ] Typecheck passes (`npm run typecheck`)
- [ ] Updated docs / comments where needed