### PR TITLE
add resource requests and limits for tasqly backend deployment

### DIFF
--- a/infra/k8s/prod/deployment.yaml
+++ b/infra/k8s/prod/deployment.yaml
@@ -36,7 +36,13 @@ spec:
 
           ports:
             - containerPort: 8080
-
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "750m"
+              memory: "1Gi"
           readinessProbe:
             httpGet:
               path: /actuator/health


### PR DESCRIPTION
## Summary

Added Kubernetes CPU and memory requests and limits for the Tasqly backend Deployment.

## Changes

- Added CPU request for the backend container
- Added memory request for the backend container
- Added CPU limit for the backend container
- Added memory limit for the backend container
- Tuned resource values for the single-node K3s EC2 host
- Preserved existing ConfigMap, Secret, probe, and ECR image pull configuration

## Resource Configuration

```yaml
resources:
  requests:
    cpu: "250m"
    memory: "512Mi"
  limits:
    cpu: "750m"
    memory: "1Gi"
```
## How to Test

- [ ] `npm run lint` (in `mobile/`)
- [ ] `npm run typecheck` (in `mobile/`)
- [ ] Manual run in Expo (`expo start`)

## Linked Issue

<!-- Example: Closes #40 -->
Closes #115

## Checklist

- [ ] Code builds locally without errors
- [ ] Linting passes (`npm run lint`)
- [ ] Typecheck passes (`npm run typecheck`)
- [ ] Updated docs / comments where needed