### PR TITLE
infra, K8s Deployment strategy

### DIFF
--- a/infra/k8s/prod/deployment.yaml
+++ b/infra/k8s/prod/deployment.yaml
@@ -9,6 +9,13 @@ metadata:
     app.kubernetes.io/environment: prod
 spec:
   replicas: 1
+
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+
   selector:
     matchLabels:
       app.kubernetes.io/name: tasqly
@@ -36,6 +43,7 @@ spec:
 
           ports:
             - containerPort: 8080
+
           resources:
             requests:
               cpu: "250m"
@@ -43,6 +51,7 @@ spec:
             limits:
               cpu: "750m"
               memory: "1Gi"
+
           readinessProbe:
             httpGet:
               path: /actuator/health


### PR DESCRIPTION
## Summary

Configured the Kubernetes Deployment update strategy for safer Tasqly backend rollouts.

## Changes

- Added explicit rolling update strategy to the backend Deployment
- Set `maxUnavailable` to `0`
- Set `maxSurge` to `1`
- Kept rollout settings suitable for a single-node K3s cluster
- Preserved existing ConfigMap, Secret, resource limit, probe, and ECR image pull configuration

## Rollout Strategy

```yaml
strategy:
  type: RollingUpdate
  rollingUpdate:
    maxUnavailable: 0
    maxSurge: 1
```
## How to Test

- [ ] `npm run lint` (in `mobile/`)
- [ ] `npm run typecheck` (in `mobile/`)
- [ ] Manual run in Expo (`expo start`)

## Linked Issue

<!-- Example: Closes #40 -->
Closes #116

## Checklist

- [ ] Code builds locally without errors
- [ ] Linting passes (`npm run lint`)
- [ ] Typecheck passes (`npm run typecheck`)
- [ ] Updated docs / comments where needed