### PR TITLE
Implement global exception handling for 404 errors

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -131,6 +131,12 @@
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>postgresql</artifactId>
+			<version>1.21.4</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/backend/src/main/java/com/backend/common/dtos/ApiErrorResponse.java
+++ b/backend/src/main/java/com/backend/common/dtos/ApiErrorResponse.java
@@ -1,0 +1,14 @@
+package com.backend.common.dtos;
+
+import java.time.Instant;
+
+public record ApiErrorResponse(
+        Instant timestamp,
+        int status,
+        String error,
+        String message,
+        String path
+
+) {
+
+}

--- a/backend/src/main/java/com/backend/common/exceptions/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/backend/common/exceptions/GlobalExceptionHandler.java
@@ -1,0 +1,31 @@
+package com.backend.common.exceptions;
+
+import com.backend.common.dtos.ApiErrorResponse;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import java.time.Instant;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public ResponseEntity<ApiErrorResponse> handleNoHandlerFound(
+            NoHandlerFoundException exception,
+            HttpServletRequest request
+    ) {
+        ApiErrorResponse response = new ApiErrorResponse(
+                Instant.now(),
+                HttpStatus.NOT_FOUND.value(),
+                HttpStatus.NOT_FOUND.getReasonPhrase(),
+                "Endpoint not found",
+                request.getRequestURI()
+        );
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+    }
+
+}

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -3,6 +3,12 @@ spring:
     url: jdbc:postgresql://localhost:5432/tasqly_test
     username: tasqly_admin
     password: tasqly_password
-
+  mvc:
+    throw-exception-if-no-handler-found: true
+  web:
+    resources:
+      add-mappings: false
   jpa:
     open-in-view: false
+  flyway:
+    enabled: true

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -1,4 +1,9 @@
 spring:
+  mvc:
+    throw-exception-if-no-handler-found: true
+    web:
+      resources:
+        add-mappings: false
   application:
     name: backend
   datasource:

--- a/backend/src/test/java/com/backend/BackendApplicationTests.java
+++ b/backend/src/test/java/com/backend/BackendApplicationTests.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -15,6 +16,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
+@Import(TestcontainersConfiguration.class)
 class BackendApplicationTests {
 
 	@Autowired
@@ -32,5 +34,15 @@ class BackendApplicationTests {
 		mockMvc.perform(get("/actuator/health"))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.status").value("UP"));
+	}
+
+	@Test
+	void unknownEndpointShouldReturnNotFound() throws Exception {
+		mockMvc.perform(get("/api/does-not-exist"))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.status").value(404))
+				.andExpect(jsonPath("$.error").value("Not Found"))
+				.andExpect(jsonPath("$.message").value("Endpoint not found"))
+				.andExpect(jsonPath("$.path").value("/api/does-not-exist"));
 	}
 }

--- a/backend/src/test/java/com/backend/TestcontainersConfiguration.java
+++ b/backend/src/test/java/com/backend/TestcontainersConfiguration.java
@@ -1,8 +1,18 @@
 package com.backend;
 
 import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
 
 @TestConfiguration(proxyBeanMethods = false)
 class TestcontainersConfiguration {
 
+    @Bean
+    @ServiceConnection
+
+    PostgreSQLContainer<?> postgresContainer() {
+        return new PostgreSQLContainer<>(DockerImageName.parse("postgres:16"));
+    }
 }


### PR DESCRIPTION
## Summary

Added global handling for unknown backend endpoints.

## Changes

- Added a standard API error response model.
- Added a global exception handler for missing endpoints.
- Added handling for unmapped routes and missing resources.
- Configured test profile to return structured 404 responses.
- Added test coverage for unknown endpoint behavior.

## Validation

- Ran backend tests with Maven.
- Confirmed unknown endpoints return HTTP 404.
- Confirmed 404 responses use the standard error format.
- Confirmed existing hello, health, and architecture tests continue to pass.

## Notes

This PR standardizes API behavior for non-existing endpoints and avoids empty/default 404 responses.

## How to Test

- [ ] `npm run lint` (in `mobile/`)
- [ ] `npm run typecheck` (in `mobile/`)
- [ ] Manual run in Expo (`expo start`)

## Linked Issue

<!-- Example: Closes #40 -->
Closes #132

## Checklist

- [ ] Code builds locally without errors
- [ ] Linting passes (`npm run lint`)
- [ ] Typecheck passes (`npm run typecheck`)
- [ ] Updated docs / comments where needed