### PR TITLE
JWT security configuration for Spring Security

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -136,6 +136,14 @@
 			<groupId>org.flywaydb</groupId>
 			<artifactId>flyway-core</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/backend/src/main/java/com/backend/auth/JwtService.java
+++ b/backend/src/main/java/com/backend/auth/JwtService.java
@@ -1,0 +1,52 @@
+package com.backend.auth;
+
+import java.time.Instant;
+
+import java.time.temporal.ChronoUnit;
+
+import java.util.UUID;
+
+import com.backend.auth.security.JwtProperties;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+
+import org.springframework.stereotype.Service;
+
+@Service
+
+public class JwtService {
+    private final JwtEncoder jwtEncoder;
+    private final JwtProperties jwtProperties;
+    public JwtService(JwtEncoder jwtEncoder, JwtProperties jwtProperties) {
+        this.jwtEncoder = jwtEncoder;
+        this.jwtProperties = jwtProperties;
+    }
+
+    public String generateAccessToken(UUID userId, String email) {
+
+        Instant now = Instant.now();
+
+        Instant expiresAt = now.plus(jwtProperties.expirationMinutes(), ChronoUnit.MINUTES);
+
+        JwtClaimsSet claims = JwtClaimsSet.builder()
+
+                .issuer(jwtProperties.issuer())
+
+                .issuedAt(now)
+
+                .expiresAt(expiresAt)
+
+                .subject(userId.toString())
+
+                .claim("email", email)
+
+                .build();
+
+        return jwtEncoder.encode(JwtEncoderParameters.from(claims)).getTokenValue();
+
+    }
+
+}

--- a/backend/src/main/java/com/backend/auth/security/JwtProperties.java
+++ b/backend/src/main/java/com/backend/auth/security/JwtProperties.java
@@ -1,0 +1,13 @@
+package com.backend.auth.security;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "tasqly.security.jwt")
+public record JwtProperties(
+        String secret,
+        String issuer,
+        long expirationMinutes
+
+) {
+
+}

--- a/backend/src/main/java/com/backend/auth/security/SecurityConfig.java
+++ b/backend/src/main/java/com/backend/auth/security/SecurityConfig.java
@@ -1,4 +1,76 @@
 package com.backend.auth.security;
 
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import com.nimbusds.jose.jwk.source.ImmutableSecret;
+
+
+@Configuration
+@EnableConfigurationProperties(JwtProperties.class)
 public class SecurityConfig {
+
+    @Bean
+    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+
+                )
+
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.GET, "/api/hello").permitAll()
+                        .requestMatchers("/actuator/health").permitAll()
+                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
+                        .requestMatchers("/api/auth/**").permitAll()
+                        .anyRequest().authenticated()
+
+                )
+
+                .oauth2ResourceServer(oauth2 ->
+                        oauth2.jwt(Customizer.withDefaults())
+                )
+                .build();
+    }
+
+    @Bean
+    JwtEncoder jwtEncoder(JwtProperties properties) {
+        SecretKey secretKey = secretKey(properties);
+        return new NimbusJwtEncoder(new ImmutableSecret<>(secretKey));
+    }
+
+    @Bean
+    JwtDecoder jwtDecoder(JwtProperties properties) {
+        SecretKey secretKey = secretKey(properties);
+        return NimbusJwtDecoder
+                .withSecretKey(secretKey)
+                .macAlgorithm(MacAlgorithm.HS256)
+                .build();
+    }
+
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    private SecretKey secretKey(JwtProperties properties) {
+        byte[] secretBytes = properties.secret().getBytes();
+        return new SecretKeySpec(secretBytes, "HmacSHA256");
+
+    }
 }

--- a/backend/src/main/java/com/backend/auth/security/SecurityConfig.java
+++ b/backend/src/main/java/com/backend/auth/security/SecurityConfig.java
@@ -2,6 +2,8 @@ package com.backend.auth.security;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
+
+import com.backend.common.exceptions.RestAuthenticationEntryPoint;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -24,6 +26,12 @@ import com.nimbusds.jose.jwk.source.ImmutableSecret;
 @EnableConfigurationProperties(JwtProperties.class)
 public class SecurityConfig {
 
+    private final RestAuthenticationEntryPoint authenticationEntryPoint;
+
+    public SecurityConfig(RestAuthenticationEntryPoint authenticationEntryPoint) {
+        this.authenticationEntryPoint = authenticationEntryPoint;
+    }
+
     @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
@@ -38,12 +46,18 @@ public class SecurityConfig {
                         .requestMatchers("/actuator/health").permitAll()
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
                         .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/public/**").permitAll()
                         .anyRequest().authenticated()
 
                 )
 
-                .oauth2ResourceServer(oauth2 ->
-                        oauth2.jwt(Customizer.withDefaults())
+                .oauth2ResourceServer(oauth2 -> oauth2
+                        .jwt(Customizer.withDefaults())
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                )
+                
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(authenticationEntryPoint)
                 )
                 .build();
     }

--- a/backend/src/main/java/com/backend/auth/security/SecurityConfig.java
+++ b/backend/src/main/java/com/backend/auth/security/SecurityConfig.java
@@ -1,0 +1,4 @@
+package com.backend.auth.security;
+
+public class SecurityConfig {
+}

--- a/backend/src/main/java/com/backend/common/config/JacksonConfig.java
+++ b/backend/src/main/java/com/backend/common/config/JacksonConfig.java
@@ -1,0 +1,13 @@
+package com.backend.common.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+@Configuration
+public class JacksonConfig {
+    @Bean
+    ObjectMapper objectMapper() {
+        return new ObjectMapper().findAndRegisterModules();
+    }
+
+}

--- a/backend/src/main/java/com/backend/common/error/ApiErrorResponse.java
+++ b/backend/src/main/java/com/backend/common/error/ApiErrorResponse.java
@@ -1,4 +1,4 @@
-package com.backend.common.dtos;
+package com.backend.common.error;
 
 import java.time.Instant;
 

--- a/backend/src/main/java/com/backend/common/exceptions/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/backend/common/exceptions/GlobalExceptionHandler.java
@@ -1,6 +1,6 @@
 package com.backend.common.exceptions;
 
-import com.backend.common.dtos.ApiErrorResponse;
+import com.backend.common.error.ApiErrorResponse;
 
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;

--- a/backend/src/main/java/com/backend/common/exceptions/RestAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/backend/common/exceptions/RestAuthenticationEntryPoint.java
@@ -1,5 +1,5 @@
 package com.backend.common.exceptions;
-import com.backend.common.dtos.ApiErrorResponse;
+import com.backend.common.error.ApiErrorResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/backend/src/main/java/com/backend/common/exceptions/RestAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/backend/common/exceptions/RestAuthenticationEntryPoint.java
@@ -1,0 +1,37 @@
+package com.backend.common.exceptions;
+import com.backend.common.dtos.ApiErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import java.io.IOException;
+import java.time.Instant;
+@Component
+public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper;
+    public RestAuthenticationEntryPoint(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException {
+        ApiErrorResponse errorResponse = new ApiErrorResponse(
+                Instant.now(),
+                HttpStatus.UNAUTHORIZED.value(),
+                HttpStatus.UNAUTHORIZED.getReasonPhrase(),
+                "Authentication is required to access this resource",
+                request.getRequestURI()
+        );
+
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType("application/json");
+        objectMapper.writeValue(response.getOutputStream(), errorResponse);
+
+    }
+}

--- a/backend/src/main/resources/application-local.yaml
+++ b/backend/src/main/resources/application-local.yaml
@@ -1,0 +1,10 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/tasqly
+    username: tasqly_admin
+    password: tasqly_password
+
+tasqly:
+  security:
+    jwt:
+      secret: "local-secret"

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -15,3 +15,10 @@ spring:
   flyway:
     enabled: true
     locations: classpath:db/migrations
+
+  tasqly:
+    security:
+      jwt:
+        secret: "test-secret"
+        issuer: tasqly-test
+        expiration-minutes: 1200

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -1,24 +1,23 @@
 spring:
-  datasource:
-    url: jdbc:postgresql://localhost:5432/tasqly_test
-    username: tasqly_admin
-    password: tasqly_password
   mvc:
     throw-exception-if-no-handler-found: true
+
   web:
     resources:
       add-mappings: false
+
   jpa:
+    open-in-view: false
     hibernate:
       ddl-auto: validate
-    open-in-view: false
+
   flyway:
     enabled: true
-    locations: classpath:db/migrations
+    locations: classpath:db/migration
 
-  tasqly:
-    security:
-      jwt:
-        secret: "test-secret"
-        issuer: tasqly-test
-        expiration-minutes: 1200
+tasqly:
+  security:
+    jwt:
+      secret: "test-secret"
+      issuer: tasqly-test
+      expiration-minutes: 60

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -20,3 +20,10 @@ spring:
   flyway:
     enabled: true
     locations: classpath:db/migrations
+
+  tasqly:
+    security:
+      jwt:
+        secret: "jwt_secret"
+        issuer: tasqly
+        expiration-minutes: 1200

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -1,29 +1,24 @@
 spring:
-  mvc:
-    throw-exception-if-no-handler-found: true
-    web:
-      resources:
-        add-mappings: false
   application:
     name: backend
-  datasource:
-    url: jdbc:postgresql://localhost:5432/tasqly
-    username: tasqly_admin
-    password: tasqly_password
-    driver-class-name: org.postgresql.Driver
-    jpa:
-      hibernate:
-        ddl-auto: validate
-      database-platform: org.hibernate.dialect.PostgreSQLDialect
-      open-in-view: false
+
+  jpa:
+    open-in-view: false
+    hibernate:
+      ddl-auto: validate
 
   flyway:
     enabled: true
-    locations: classpath:db/migrations
+    locations: classpath:db/migration
 
-  tasqly:
-    security:
-      jwt:
-        secret: "jwt_secret"
-        issuer: tasqly
-        expiration-minutes: 1200
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+
+tasqly:
+  security:
+    jwt:
+      issuer: tasqly
+      expiration-minutes: 60

--- a/backend/src/test/java/com/backend/BackendApplicationTests.java
+++ b/backend/src/test/java/com/backend/BackendApplicationTests.java
@@ -37,12 +37,12 @@ class BackendApplicationTests {
 	}
 
 	@Test
-	void unknownEndpointShouldReturnNotFound() throws Exception {
+	void unknownProtectedEndpointShouldReturnUnauthorized() throws Exception {
 		mockMvc.perform(get("/api/does-not-exist"))
-				.andExpect(status().isNotFound())
-				.andExpect(jsonPath("$.status").value(404))
-				.andExpect(jsonPath("$.error").value("Not Found"))
-				.andExpect(jsonPath("$.message").value("Endpoint not found"))
+				.andExpect(status().isUnauthorized())
+				.andExpect(jsonPath("$.status").value(401))
+				.andExpect(jsonPath("$.error").value("Unauthorized"))
+				.andExpect(jsonPath("$.message").value("Authentication is required to access this resource"))
 				.andExpect(jsonPath("$.path").value("/api/does-not-exist"));
 	}
 }


### PR DESCRIPTION
## Summary

Added the backend security baseline using Spring Security and JWT.

## Changes

- Added Spring Security configuration.
- Configured stateless authentication for the backend API.
- Added JWT encoder and decoder support.
- Added JWT configuration properties.
- Added password encoder bean for future authentication flows.
- Defined public routes for health, API docs, hello endpoint, and auth endpoints.
- Protected all other backend routes by default.
- Added structured JSON response handling for unauthorized requests.
- Added test configuration for JWT security values.

## Validation

- Ran backend tests with Maven.
- Confirmed public endpoints remain accessible.
- Confirmed protected endpoints reject unauthenticated requests.
- Confirmed unauthorized responses return structured JSON.
- Confirmed health endpoint remains publicly accessible.
- Confirmed backend starts successfully with security enabled.

## Notes

This PR only adds the security foundation. User registration, sign-in, user lookup, role-based access control, and token issuing from real user credentials will be implemented in separate tickets.

## How to Test

- [ ] `npm run lint` (in `mobile/`)
- [ ] `npm run typecheck` (in `mobile/`)
- [ ] Manual run in Expo (`expo start`)

## Linked Issue

<!-- Example: Closes #40 -->
Closes #134 

## Checklist

- [ ] Code builds locally without errors
- [ ] Linting passes (`npm run lint`)
- [ ] Typecheck passes (`npm run typecheck`)
- [ ] Updated docs / comments where needed